### PR TITLE
Drop vault usage from medical-diagnosis

### DIFF
--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -10,7 +10,6 @@ clusterGroup:
   - xraylab-1
   - knative-serving
   - staging
-  - vault
   - medical-diagnosis-datacenter
 
   operatorgroupExcludes:
@@ -123,27 +122,6 @@ clusterGroup:
       namespace: xraylab-1
       project: datacenter
       path: charts/datacenter/xraylab/xraydb
-
-    hashivault:
-      name: hashivault
-      namespace: vault
-      project: datacenter
-      chart: vault
-      repoURL: https://helm.releases.hashicorp.com
-      targetRevision: 0.17.1
-      overrides:
-      - name: build.enabled
-        value: "false"
-        forceString: true
-      - name: deploy.route.tls.enabled
-        value: "true"
-        forceString: true
-      - name: global.openshift
-        value: "true"
-        forceString: true
-      - name: server.dev.enabled
-        value: "true"
-        forceString: true
 
 #  To have apps in multiple flavors, use namespaces and use helm overrides as appropriate
 #


### PR DESCRIPTION
It's currently not used, so it is just confusing and uses resources
needlessly. After this change we have:

    $ grep -iR vault 2>/dev/null|grep -v ^common
    $
