### PR TITLE
Cleanup pattern Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,4 @@
-ARGO_TARGET_NAMESPACE=xraylab-1
 PATTERN=medical-diagnosis
-COMPONENT=datacenter
-SECRET_NAME="argocd-env"
-TARGET_REPO=$(shell git remote show origin | grep Push | sed -e 's/.*URL://' -e 's%:[a-z].*@%@%' -e 's%:%/%' -e 's%git@%https://%' )
-CHART_OPTS=-f values-global.yaml -f values-datacenter.yaml --set global.targetRevision=main --set global.valuesDirectoryURL="https://github.com/pattern-clone/pattern/raw/main/" --set global.pattern="medical-diagnosis" --set global.namespace="pattern-namespace"
 
 .PHONY: default
 default: show


### PR DESCRIPTION
We remove the following lines:
1. ARGO_TARGET_NAMESPACE=xraylab-1 -> unused
$ grep -R ARGO_TARGET_N
Makefile:ARGO_TARGET_NAMESPACE=xraylab-1

2. COMPONENT=datacenter -> unused
$ grep -R COMPONENT
Makefile:COMPONENT=datacenter

3. TARGET_REPO
This one is already defined in common/Makefile
(and has a couple of fixes since this was added in the
top-level Makefile)

4. CHART_OPTS
This is defined in common/Makefile and we can reuse it without
overriding it

5. SECRET_NAME="argocd-env" -> unused
$ grep -R SECRET_NAME
Makefile:SECRET_NAME="argocd-env"
