### PR TITLE
Upgrade vault-chart to v0.20.1

### DIFF
--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -53,7 +53,7 @@ clusterGroup:
     project: datacenter
     chart: vault
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: v0.20.0
+    targetRevision: v0.20.1
     overrides:
     - name: global.openshift
       value: "true"


### PR DESCRIPTION
We already did so in multicloud-gitops
