### PR TITLE
 Add validate-origin to install target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 ./values-secret.yaml
 *.swp
 *.vscode
-
+super-linter.log

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ default: show
 	echo "Delegating $* target"
 	make -f common/Makefile $*
 
-install: deploy
+install: validate-origin deploy
 	echo "Bootstrapping Medical Diagnosis Pattern"
 	make vault-init
 	make load-secrets


### PR DESCRIPTION
The 'validate-origin' target checks that the detected branch actually
exists in the remote git repository (see common/Makefile) and bails
out if it does not (because gitops would never work in such cases)
