### PR TITLE
Add secret template per mbp-349

### DIFF
--- a/values-secret.yaml.template
+++ b/values-secret.yaml.template
@@ -1,0 +1,18 @@
+---
+secrets:
+  # NEVER COMMIT THESE VALUES TO GIT
+  
+  # Database login credentials and configuration 
+  xraylab:
+    database-user: xraylab
+    database-password: PLAINTEXT
+    database-root-password: PLAINTEXT
+    database-host: xraylabdb
+    database-db: xraylabdb
+    database-master-user: xraylab
+    database-master-password: PLAINTEXT
+  
+  # Grafana Dashboard admin user/password
+  grafana:
+    GF_SECURITY_ADMIN_USER: root
+    GF_SECURITY_ADMIN_PASSWORD: PLAINTEXT


### PR DESCRIPTION
There was no existing template for secrets in the medical-diagnosis
pattern. Added a template with relevant entries to align with the rest
of the pattern framework.