### PR TITLE
Removing extra namespace from values-hub

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -15,7 +15,6 @@ clusterGroup:
   - staging
   - vault
   - golang-external-secrets
-  - medical-diagnosis-datacenter
 
   subscriptions:
     amq-streams:


### PR DESCRIPTION
medical-diagnosis-datacenter namespace is no longer required due to the shift to new project scaffolding.