### PR TITLE
Switch IE to deploy by default via the operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,20 @@ default: show
 	echo "Delegating $* target"
 	make -f common/Makefile $*
 
-install: validate-origin deploy
-	echo "Bootstrapping Medical Diagnosis Pattern"
-	make vault-init
-	make load-secrets
+install: operator-deploy post-install ## installs the pattern, inits the vault and loads the secrets
 	echo "Installed"
+
+legacy-install: legacy-deploy post-install ## install the pattern the old way without the operator
+	echo "Installed"
+
+post-install: ## Post-install tasks - vault init and load-secrets
+	@if grep -v -e '^\s\+#' "values-hub.yaml" | grep -q -e "insecureUnsealVaultInsideCluster:\s\+true"; then \
+	  echo "Skipping 'make vault-init' as we're unsealing the vault from inside the cluster"; \
+	else \
+	  make vault-init; \
+	fi
+	make load-secrets
+	echo "Done"
 
 update: upgrade
 	echo "Bootstrapping Medical Diagnosis Pattern"

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -3,7 +3,7 @@ clusterGroup:
   isHubCluster: true
   # Note: setting this to true stores the vault unseal keys inside a cluster secret and
   # is fundamentally insecure
-  insecureUnsealVaultInsideCluster: false
+  insecureUnsealVaultInsideCluster: true
 
   namespaces:
   - open-cluster-management


### PR DESCRIPTION
There is still the 'legacy-install' target for the non-operator driven
installation and switch to unsealing inside the vault inside the cluster.

Also consolidate the post-install action a bit.
