### PR TITLE
Add library path to ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,4 +2,5 @@
 display_skipped_hosts=False
 localhost_warning=False
 retry_files_enabled=False
-roles_path=./ansible/roles:./common/ansible/roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+library=~/.ansible/plugins/modules:./ansible/plugins/modules:./common/ansible/plugins/modules:/usr/share/ansible/plugins/modules
+roles_path=~/.ansible/roles:./ansible/roles:./common/ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles


### PR DESCRIPTION
See https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-module-path
we make sure we can add python modules in both ansible/ and
common/ansible (although realistically we'll only add them into
common/ansible)

This is in preparation of the python rewrite of common/ansible
push_secrets

Also shuffle the order of roles_path so overriding a role locally is
easier.
