### PR TITLE
common automatic update

### DIFF
--- a/common/.github/workflows/ansible-unittest.yml
+++ b/common/.github/workflows/ansible-unittest.yml
@@ -20,7 +20,7 @@ jobs:
     name: Ansible unit tests
     strategy:
       matrix:
-        python-version: [3.10.9]
+        python-version: [3.10.10]
     # Set the agent to run on
     runs-on: ubuntu-latest
 

--- a/common/.github/workflows/jsonschema.yaml
+++ b/common/.github/workflows/jsonschema.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Json Schema tests
     strategy:
       matrix:
-        python-version: [3.11.1]
+        python-version: [3.11.2]
     # Set the agent to run on
     runs-on: ubuntu-latest
 

--- a/common/Changes.md
+++ b/common/Changes.md
@@ -1,5 +1,9 @@
 # Changes
 
+## February 9, 2023
+
+* Add support for /values-<platform>.yaml and for /values-<platform>-<clusterversion>.yaml
+
 ## January 29, 2023
 
 * Stop extracting the HUB's CA via an imperative job running on the imported cluster.

--- a/common/Makefile
+++ b/common/Makefile
@@ -3,6 +3,10 @@ ifneq ($(origin TARGET_SITE), undefined)
   TARGET_SITE_OPT=--set main.clusterGroupName=$(TARGET_SITE)
 endif
 
+# INDEX_IMAGES=registry-proxy.engineering.redhat.com/rh-osbs/iib:394248
+INDEX_IMAGES ?= 
+INDEX_OPTIONS=$(shell echo $(INDEX_IMAGES) | tr ',' '\n' | awk -F: 'match($$1,"/"){print "--set main.extraParameters."NR".name=clusterGroup.indexImages."NR".image --set main.extraParameters."NR".value="$$1":"$$2}')
+
 TARGET_ORIGIN ?= origin
 # This is to ensure that whether we start with a git@ or https:// URL, we end up with an https:// URL
 # This is because we expect to use tokens for repo authentication as opposed to SSH keys
@@ -11,7 +15,7 @@ TARGET_REPO=$(shell git ls-remote --get-url --symref $(TARGET_ORIGIN) | sed -e '
 TARGET_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 # --set values always take precedence over the contents of -f
-HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT)
+HELM_OPTS=-f values-global.yaml --set main.git.repoURL="$(TARGET_REPO)" --set main.git.revision=$(TARGET_BRANCH) $(TARGET_SITE_OPT) $(INDEX_OPTIONS)
 
 ##@ Pattern Common Tasks
 

--- a/common/acm/templates/policies/acm-hub-ca-policy.yaml
+++ b/common/acm/templates/policies/acm-hub-ca-policy.yaml
@@ -55,6 +55,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-hub-ca-policy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/common/acm/templates/policies/application-policies.yaml
+++ b/common/acm/templates/policies/application-policies.yaml
@@ -45,6 +45,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-{{ .name }}.yaml"
+                      - '/values-{{ `{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}` }}.yaml'
+                      - '/values-{{ `{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}` }}-{{ `{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}` }}.yaml'
                       - '/values-{{ `{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}` }}-{{ .name }}.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version
@@ -122,6 +124,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: {{ .name }}-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/common/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/common/acm/templates/policies/ocp-gitops-policy.yaml
@@ -64,6 +64,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/common/ansible/roles/vault_utils/README.md
+++ b/common/ansible/roles/vault_utils/README.md
@@ -44,8 +44,9 @@ This relies on [kubernetes.core](https://docs.ansible.com/ansible/latest/collect
 
 Currently this role supports two formats: version 1.0 (which is the assumed default when not specified) and version 2.0.
 The latter is more fatureful and supports generating secrets directly into the vault and also prompting the user for a secret.
-By default, the first file that will looked up is `~/values-secret-<patternname>.yaml` and should that not exist it will look
-for `~/values-secret.yaml`. The paths can be overridden by setting the environment variable `VALUES_SECRET` to the path of the
+By default, the first file that will looked up is `~/.config/hybrid-cloud-patterns/values-secret-<patternname>.yaml`, then
+`~/values-secret-<patternname>.yaml` and should that not exist it will look for `~/values-secret.yaml`.
+The paths can be overridden by setting the environment variable `VALUES_SECRET` to the path of the
 secret file.
 
 The values secret yaml files can be encrypted with `ansible-vault`. If the role detects they are encrypted, the password to

--- a/common/ansible/roles/vault_utils/tasks/push_secrets.yaml
+++ b/common/ansible/roles/vault_utils/tasks/push_secrets.yaml
@@ -58,11 +58,14 @@
     - custom_env_values_secret | default('') | length > 0
     - custom_file_values_secret.stat.exists
 
+# FIXME(bandini): Eventually around end of 2023(?) we should drop
+# ~/values-secret-{{ pattern_name }}.yaml and ~/values-secret.yaml
 - name: Find first existing values-secret yaml file
   ansible.builtin.set_fact:
     found_file: "{{ lookup('ansible.builtin.first_found', findme) }}"
   vars:
     findme:
+      - "~/.config/hybrid-cloud-patterns/values-secret-{{ pattern_name }}.yaml"
       - "~/values-secret-{{ pattern_name }}.yaml"
       - "~/values-secret.yaml"
       - "{{ pattern_dir }}/values-secret.yaml.template"
@@ -76,6 +79,10 @@
   changed_when: false
   register: encrypted
   failed_when: (encrypted.rc not in [0, 1])
+
+- name: Is found values secret file encrypted
+  ansible.builtin.debug:
+    msg: "Using {{ found_file }} to parse secrets"
 
 - name: Set encryption bool fact
   no_log: true

--- a/common/clustergroup/templates/core/catalog-sources.yaml
+++ b/common/clustergroup/templates/core/catalog-sources.yaml
@@ -1,13 +1,14 @@
 {{- if not (eq .Values.enabled "plumbing") }}
 {{- range .Values.clusterGroup.indexImages }}
+{{- $name := mustRegexReplaceAll "[^/]*/(.*):.*" .image "${1}" | replace "/" "-" }}
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: {{ .name }}
+  name: {{ coalesce .name $name }}
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: {{ .image }}:{{ .version }}
+  image: {{ .image }}
 ---
 {{- end -}}
 {{- end -}}

--- a/common/clustergroup/templates/plumbing/applications.yaml
+++ b/common/clustergroup/templates/plumbing/applications.yaml
@@ -152,6 +152,10 @@ spec:
       - "/values-global.yaml"
       - "/values-{{ $.Values.clusterGroup.name }}.yaml"
       {{- if $.Values.global.clusterPlatform }}
+      - "/values-{{ $.Values.global.clusterPlatform }}.yaml"
+        {{- if $.Values.global.clusterVersion }}
+      - "/values-{{ $.Values.global.clusterPlatform }}-{{ $.Values.global.clusterVersion }}.yaml"
+        {{- end }}
       - "/values-{{ $.Values.global.clusterPlatform }}-{{ $.Values.clusterGroup.name }}.yaml"
       {{- end }}
       {{- if $.Values.global.clusterVersion }}

--- a/common/clustergroup/test.yaml
+++ b/common/clustergroup/test.yaml
@@ -10,8 +10,7 @@ clusterGroup:
 
   indexImages:
   - name: snr
-    image: quay.io/mshitrit/self-node-remediation-manager-index
-    version: 0.0.104
+    image: quay.io/mshitrit/self-node-remediation-manager-index:0.0.104
 
   subscriptions:
     acm:

--- a/common/clustergroup/values.schema.json
+++ b/common/clustergroup/values.schema.json
@@ -148,7 +148,7 @@
     },
     "GlobalGit": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "The git configuration used to support Tekton pipeline tasks.",
       "properties": {
         "hostname": {
@@ -221,6 +221,20 @@
           "description": "This is the array of namespaces that the VP framework will create.  In addition, operator groups will also be created for each namespace.",
           "items": {
             "type": "string"
+          }
+        },
+        "indexImages": {
+          "anyOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "object"
+            }
+          ],
+          "description": "List of index images for overriding default catalog sources.",
+          "items": {
+            "$ref": "#/definitions/IndexImages"
           }
         },
         "operatorgroupExcludes": {
@@ -395,6 +409,21 @@
         "project"
       ],
       "title": "Applications"
+    },
+    "IndexImages": {
+      "type": "object",
+      "description": "Details for overriding default catalog sources",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name for the custom catalog source."
+        },
+        "image": {
+          "type": "string",
+          "description": "Location of the index image."
+        }
+      }
     },
     "HostedSite": {
       "type": "object",

--- a/common/operator-install/templates/pattern.yaml
+++ b/common/operator-install/templates/pattern.yaml
@@ -10,3 +10,10 @@ spec:
     targetRevision: {{ .Values.main.git.revision }}
   gitOpsSpec:
     operatorChannel: {{ default "stable" .Values.main.gitops.channel }}
+{{- if .Values.main.extraParameters }}
+  extraParameters:
+{{- range .Values.main.extraParameters }}
+  - name: {{ .name }}
+    value: {{ .value }}
+{{- end }}
+{{- end }}

--- a/common/scripts/pattern-util.sh
+++ b/common/scripts/pattern-util.sh
@@ -4,14 +4,19 @@ if [ -z "$PATTERN_UTILITY_CONTAINER" ]; then
 	PATTERN_UTILITY_CONTAINER="quay.io/hybridcloudpatterns/utility-container"
 fi
 
+UNSUPPORTED_PODMAN_VERSIONS="1.6 1.5"
+for i in ${UNSUPPORTED_PODMAN_VERSIONS}; do
+	# We add a space
+	if podman --version | grep -q -E "\b${i}"; then
+		echo "Unsupported podman version. We recommend >= 4.2.0"
+		podman --version
+		exit 1
+	fi
+done
+
 # Copy Kubeconfig from current environment. The utilities will pick up ~/.kube/config if set so it's not mandatory
 # $HOME is mounted as itself for any files that are referenced with absolute paths
 # $HOME is mounted to /root because the UID in the container is 0 and that's where SSH looks for credentials
-# We bind mount the SSH_AUTH_SOCK socket if it is set, so ssh works without user prompting
-SSH_SOCK_MOUNTS=""
-if [ -n "$SSH_AUTH_SOCK" ]; then
-	SSH_SOCK_MOUNTS="-v ${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK} -e SSH_AUTH_SOCK=${SSH_AUTH_SOCK}"
-fi
 
 # We must pass -e KUBECONFIG *only* if it is set, otherwise we end up passing
 # KUBECONFIG="" which then will confuse ansible
@@ -20,13 +25,14 @@ if [ -n "$KUBECONFIG" ]; then
 	KUBECONF_ENV="-e KUBECONFIG=${KUBECONFIG}"
 fi
 
+# Do not quote the ${KUBECONF_ENV} below, otherwise we will pass '' to podman
+# which will be confused
 podman run -it \
 	--security-opt label=disable \
 	${KUBECONF_ENV} \
-	${SSH_SOCK_MOUNTS} \
-	-v ${HOME}:${HOME} \
-	-v ${HOME}:/pattern-home \
-	-v ${HOME}:/root \
-	-w $(pwd) \
+	-v "${HOME}":"${HOME}" \
+	-v "${HOME}":/pattern-home \
+	-v "${HOME}":/root \
+	-w "$(pwd)" \
 	"$PATTERN_UTILITY_CONTAINER" \
 	$@

--- a/common/tests/acm-industrial-edge-factory.expected.yaml
+++ b/common/tests/acm-industrial-edge-factory.expected.yaml
@@ -36,6 +36,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/common/tests/acm-industrial-edge-hub.expected.yaml
+++ b/common/tests/acm-industrial-edge-hub.expected.yaml
@@ -65,6 +65,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-hub-ca-policy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -81,6 +83,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: factory-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -105,6 +109,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -197,6 +203,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-factory.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-factory.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/common/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/common/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -65,6 +65,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-hub-ca-policy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -81,6 +83,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: region-one-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -96,6 +100,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -188,6 +194,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-region-one.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-region-one.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/common/tests/acm-naked.expected.yaml
+++ b/common/tests/acm-naked.expected.yaml
@@ -36,6 +36,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/common/tests/acm-normal.expected.yaml
+++ b/common/tests/acm-normal.expected.yaml
@@ -470,6 +470,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-hub-ca-policy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -486,6 +488,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-edge-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -499,6 +503,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-provision-edge-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -512,6 +518,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -604,6 +612,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-edge.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-edge.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version
@@ -694,6 +704,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-provision-edge.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-provision-edge.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/tests/common-acm-industrial-edge-factory.expected.yaml
+++ b/tests/common-acm-industrial-edge-factory.expected.yaml
@@ -36,6 +36,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/tests/common-acm-industrial-edge-hub.expected.yaml
+++ b/tests/common-acm-industrial-edge-hub.expected.yaml
@@ -65,6 +65,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-hub-ca-policy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -81,6 +83,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: factory-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -105,6 +109,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -197,6 +203,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-factory.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-factory.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/tests/common-acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-acm-medical-diagnosis-hub.expected.yaml
@@ -65,6 +65,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-hub-ca-policy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -81,6 +83,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: region-one-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -96,6 +100,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -188,6 +194,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-region-one.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-region-one.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version

--- a/tests/common-acm-naked.expected.yaml
+++ b/tests/common-acm-naked.expected.yaml
@@ -36,6 +36,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'

--- a/tests/common-acm-normal.expected.yaml
+++ b/tests/common-acm-normal.expected.yaml
@@ -470,6 +470,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-hub-ca-policy-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -486,6 +488,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-edge-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -499,6 +503,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: acm-provision-edge-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -512,6 +518,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: openshift-gitops-placement
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   clusterConditions:
     - status: 'True'
@@ -604,6 +612,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-edge.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-edge.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version
@@ -694,6 +704,8 @@ spec:
                       valueFiles:
                       - "/values-global.yaml"
                       - "/values-acm-provision-edge.yaml"
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}.yaml'
+                      - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-{{ printf "%d.%d" ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Major) ((semver (lookup "operator.openshift.io/v1" "OpenShiftControllerManager" "" "cluster").status.version).Minor) }}.yaml'
                       - '/values-{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type }}-acm-provision-edge.yaml'
                       # We cannot use $.Values.global.clusterVersion because that gets resolved to the
                       # hub's cluster version, whereas we want to include the spoke cluster version


### PR DESCRIPTION
- Allow additional properties for GlobalGit
- Print which files we are using to parse values secrets
- Drop SSH_SOCK_MOUNT from pattern-util.sh
- Add /values-<platform>.yaml and /values-<platform>-<clusterversion>.yaml support
- Bail out on unsupported podman versions
- Use more recent python versions to unreak CI
- Escape all the variables
- Add index image support to the schema
- Consume versioned index images, and provide a default name
- Allow index images to be a map to avoid accidental overrides
- Support passing index images as extra parameters
- Update index image example
- Add SkipDryRunOnMissingResource=true to all PlacementRules
- Do not quote KUBECONF_ENV
- Add support for ~/.config/hybrid-cloud-patterns folder to store secrets
- Add a comment about removing older search paths
- Fix up common/ tests
