### PR TITLE
CSI Provisioner/storageclass support for hyperscalers

### DIFF
--- a/values-4.10-hub.yaml
+++ b/values-4.10-hub.yaml
@@ -1,6 +1,0 @@
-clusterGroup:
-  subscriptions:
-    odf:
-      name: odf-operator
-      namespace: openshift-storage
-      channel: stable-4.10

--- a/values-4.11-hub.yaml
+++ b/values-4.11-hub.yaml
@@ -1,6 +1,0 @@
-clusterGroup:
-  subscriptions:
-    odf:
-      name: odf-operator
-      namespace: openshift-storage
-      channel: stable-4.11

--- a/values-AWS-4.10.yaml
+++ b/values-AWS-4.10.yaml
@@ -1,0 +1,3 @@
+global:
+  datacenter:
+    storageClassName: gp2

--- a/values-AWS.yaml
+++ b/values-AWS.yaml
@@ -1,0 +1,3 @@
+global:
+  datacenter:
+    storageClassName: gp3-csi

--- a/values-Azure-4.10.yaml
+++ b/values-Azure-4.10.yaml
@@ -1,0 +1,3 @@
+global:
+  datacenter:
+    storageClassName: managed-premium

--- a/values-Azure.yaml
+++ b/values-Azure.yaml
@@ -1,3 +1,3 @@
 global:
   datacenter:
-    storageClassName: managed-premium
+    storageClassName: managed-csi

--- a/values-Azure.yaml
+++ b/values-Azure.yaml
@@ -1,0 +1,3 @@
+global:
+  datacenter:
+    storageClassName: managed-premium

--- a/values-GCP-4.10.yaml
+++ b/values-GCP-4.10.yaml
@@ -1,0 +1,3 @@
+global:
+  datacenter:
+    storageClassName: standard

--- a/values-GCP.yaml
+++ b/values-GCP.yaml
@@ -1,0 +1,3 @@
+global:
+  datacenter:
+    storageClassName: standard-csi

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -17,22 +17,18 @@ clusterGroup:
     amq-streams:
       name: amq-streams
       namespace: xraylab-1
-      channel: stable
     
     grafana:
       name: grafana-operator
       namespace: xraylab-1
-      channel: v4
       source: community-operators
 
     odf:
       name: odf-operator
       namespace: openshift-storage
-      channel: stable-4.11
 
     severless:
       name: serverless-operator
-      channel: stable
 
     opendatahub:
       name: opendatahub-operator


### PR DESCRIPTION
Replaced existing values-$OCPVER-hub.yaml with more specific values-$…

This is to support the new csi provisioners and storageclass in the big3 public clouds.

Removed the channel parameter from the values-hub.yaml file so that operator subscriptions will use the default channel for the given operator.