### PR TITLE
common automatic update

### DIFF
--- a/common/Changes.md
+++ b/common/Changes.md
@@ -1,5 +1,13 @@
 # Changes
 
+## Apr 11, 2023
+
+* Apply the ACM ocp-gitops-policy everywhere but the hub
+
+## Apr 7, 2023
+
+* Moved to gitops-1.8 channel by default (stable is unmaintained and will be dropped starting with ocp-4.13)
+
 ## March 20, 2023
 
 * Upgraded ESO to 0.8.1

--- a/common/acm/templates/policies/ocp-gitops-policy.yaml
+++ b/common/acm/templates/policies/ocp-gitops-policy.yaml
@@ -35,7 +35,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: {{ default "gitops-1.8" .Values.main.gitops.channel }}
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators
@@ -76,3 +76,7 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'

--- a/common/acm/values.yaml
+++ b/common/acm/values.yaml
@@ -1,3 +1,7 @@
+main:
+  gitops:
+    channel: "gitops-1.8"
+
 global:
   pattern: none
   repoURL: none

--- a/common/ansible/roles/vault_utils/tasks/vault_spokes_init.yaml
+++ b/common/ansible/roles/vault_utils/tasks/vault_spokes_init.yaml
@@ -45,7 +45,7 @@
 
 - name: Merge the two dicts together
   ansible.builtin.set_fact:
-    clusters_info: "{{ clusters | combine(cleaned_acm_secrets, recursive=True) }}"
+    clusters_info: "{{ clusters | default({}) | combine(cleaned_acm_secrets, recursive=True) }}"
 
 - name: Write out CAs
   ansible.builtin.copy:
@@ -57,6 +57,13 @@
   loop_control:
     label: "{{ item.key }}"
 
+# FIXME(bandini): validate_certs is false due to an ACM bug when using
+# letsencrypt certificates with API endpoints: https://issues.redhat.com/browse/ACM-4398
+# We always verify the CA chain except when letsencrypt.api_endpoint is set to true
+- name: If we are using letsencrypt on the API endpoints we cannot use the validate_certs later
+  ansible.builtin.set_fact:
+    validate_certs_api_endpoint: "{{ not letsencrypt.api_endpoint | default(True) | bool }}"
+
 - name: Fetch remote ansible to remote cluster
   kubernetes.core.k8s_info:
     api_key: "{{ item.value['bearerToken'] }}"
@@ -66,6 +73,7 @@
     namespace: "{{ external_secrets_ns }}"
     name: "{{ external_secrets_secret }}"
     api_version: v1
+    validate_certs: "{{ validate_certs_api_endpoint }}"
   register: remote_external_secrets_sa
   when:
     - clusters_info[item.key]['bearerToken'] is defined

--- a/common/operator-install/crds/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/common/operator-install/crds/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -84,7 +82,7 @@ spec:
                     type: string
                   operatorChannel:
                     description: 'Channel to deploy openshift-gitops from. Default:
-                      stable'
+                      gitops-1.8'
                     type: string
                   operatorSource:
                     description: 'Source to deploy openshift-gitops from. Default:
@@ -102,19 +100,24 @@ spec:
                       from TargetRepo is broken
                     type: string
                   originRepo:
-                    description: Unused
+                    description: Upstream git repo containing the pattern to deploy.
+                      Used when in-cluster fork to point to the upstream pattern repository
                     type: string
+                  originRevision:
+                    description: Branch, tag or commit in the upstream git repository.
+                      Does not support short-sha's. Default to HEAD
+                    type: string
+                  pollInterval:
+                    description: 'Interval in seconds to poll for drifts between origin
+                      and target repositories. Default: 180 seconds'
+                    type: integer
                   targetRepo:
                     description: Git repo containing the pattern to deploy. Must use
                       https/http
                     type: string
                   targetRevision:
                     description: 'Branch, tag, or commit to deploy.  Does not support
-                      short-sha''s. Default: main'
-                    type: string
-                  valuesDirectoryURL:
-                    description: Optional. Alternate URL to obtain Helm values files
-                      from instead of this pattern.
+                      short-sha''s. Default: HEAD'
                     type: string
                 required:
                 - targetRepo
@@ -126,6 +129,8 @@ spec:
           status:
             description: PatternStatus defines the observed state of Pattern
             properties:
+              appClusterDomain:
+                type: string
               clusterDomain:
                 type: string
               clusterID:
@@ -134,6 +139,36 @@ spec:
                 type: string
               clusterPlatform:
                 type: string
+              clusterVersion:
+                type: string
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of deployment condition.
+                      type: string
+                  required:
+                  - lastUpdateTime
+                  - status
+                  - type
+                  type: object
+                type: array
               lastError:
                 description: Last error encountered by the pattern
                 type: string

--- a/common/operator-install/templates/pattern.yaml
+++ b/common/operator-install/templates/pattern.yaml
@@ -9,7 +9,7 @@ spec:
     targetRepo: {{ .Values.main.git.repoURL }}
     targetRevision: {{ .Values.main.git.revision }}
   gitOpsSpec:
-    operatorChannel: {{ default "stable" .Values.main.gitops.channel }}
+    operatorChannel: {{ default "gitops-1.8" .Values.main.gitops.channel }}
 {{- if .Values.main.extraParameters }}
   extraParameters:
 {{- range .Values.main.extraParameters }}

--- a/common/operator-install/values.yaml
+++ b/common/operator-install/values.yaml
@@ -4,6 +4,6 @@ main:
     revision: main
 
   gitops:
-    channel: "stable"
+    channel: "gitops-1.8"
 
   clusterGroupName: default

--- a/common/reference-output.yaml
+++ b/common/reference-output.yaml
@@ -112,7 +112,7 @@ metadata:
   labels:
     operators.coreos.com/openshift-gitops-operator.openshift-operators: ""
 spec:
-  channel: stable
+  channel: gitops-1.8
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators

--- a/common/tests/acm-industrial-edge-factory.expected.yaml
+++ b/common/tests/acm-industrial-edge-factory.expected.yaml
@@ -48,6 +48,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -87,7 +91,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: gitops-1.8
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/common/tests/acm-industrial-edge-hub.expected.yaml
+++ b/common/tests/acm-industrial-edge-hub.expected.yaml
@@ -121,6 +121,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -289,7 +293,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: gitops-1.8
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/common/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/common/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -112,6 +112,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -280,7 +284,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: gitops-1.8
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/common/tests/acm-naked.expected.yaml
+++ b/common/tests/acm-naked.expected.yaml
@@ -48,6 +48,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -87,7 +91,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: gitops-1.8
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/common/tests/acm-normal.expected.yaml
+++ b/common/tests/acm-normal.expected.yaml
@@ -530,6 +530,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -790,7 +794,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: gitops-1.8
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/common/tests/operator-install-industrial-edge-factory.expected.yaml
+++ b/common/tests/operator-install-industrial-edge-factory.expected.yaml
@@ -11,7 +11,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
   gitOpsSpec:
-    operatorChannel: stable
+    operatorChannel: gitops-1.8
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/common/tests/operator-install-industrial-edge-hub.expected.yaml
+++ b/common/tests/operator-install-industrial-edge-hub.expected.yaml
@@ -11,7 +11,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
   gitOpsSpec:
-    operatorChannel: stable
+    operatorChannel: gitops-1.8
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/common/tests/operator-install-medical-diagnosis-hub.expected.yaml
+++ b/common/tests/operator-install-medical-diagnosis-hub.expected.yaml
@@ -11,7 +11,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
   gitOpsSpec:
-    operatorChannel: stable
+    operatorChannel: gitops-1.8
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/common/tests/operator-install-naked.expected.yaml
+++ b/common/tests/operator-install-naked.expected.yaml
@@ -11,7 +11,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
   gitOpsSpec:
-    operatorChannel: stable
+    operatorChannel: gitops-1.8
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/common/tests/operator-install-normal.expected.yaml
+++ b/common/tests/operator-install-normal.expected.yaml
@@ -11,7 +11,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
   gitOpsSpec:
-    operatorChannel: stable
+    operatorChannel: gitops-1.8
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-acm-industrial-edge-factory.expected.yaml
+++ b/tests/common-acm-industrial-edge-factory.expected.yaml
@@ -48,6 +48,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -87,7 +91,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: gitops-1.8
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/tests/common-acm-industrial-edge-hub.expected.yaml
+++ b/tests/common-acm-industrial-edge-hub.expected.yaml
@@ -121,6 +121,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -289,7 +293,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: gitops-1.8
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/tests/common-acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-acm-medical-diagnosis-hub.expected.yaml
@@ -112,6 +112,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -280,7 +284,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: gitops-1.8
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/tests/common-acm-naked.expected.yaml
+++ b/tests/common-acm-naked.expected.yaml
@@ -48,6 +48,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/ocp-gitops-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -87,7 +91,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: gitops-1.8
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/tests/common-acm-normal.expected.yaml
+++ b/tests/common-acm-normal.expected.yaml
@@ -530,6 +530,10 @@ spec:
         operator: In
         values:
           - OpenShift
+      - key: local-cluster
+        operator: NotIn
+        values:
+          - 'true'
 ---
 # Source: acm/templates/policies/acm-hub-ca-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -790,7 +794,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: gitops-1.8
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators

--- a/tests/common-operator-install-industrial-edge-factory.expected.yaml
+++ b/tests/common-operator-install-industrial-edge-factory.expected.yaml
@@ -11,7 +11,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
   gitOpsSpec:
-    operatorChannel: stable
+    operatorChannel: gitops-1.8
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-industrial-edge-hub.expected.yaml
+++ b/tests/common-operator-install-industrial-edge-hub.expected.yaml
@@ -11,7 +11,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
   gitOpsSpec:
-    operatorChannel: stable
+    operatorChannel: gitops-1.8
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-operator-install-medical-diagnosis-hub.expected.yaml
@@ -11,7 +11,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
   gitOpsSpec:
-    operatorChannel: stable
+    operatorChannel: gitops-1.8
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-naked.expected.yaml
+++ b/tests/common-operator-install-naked.expected.yaml
@@ -11,7 +11,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
   gitOpsSpec:
-    operatorChannel: stable
+    operatorChannel: gitops-1.8
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1

--- a/tests/common-operator-install-normal.expected.yaml
+++ b/tests/common-operator-install-normal.expected.yaml
@@ -11,7 +11,7 @@ spec:
     targetRepo: https://github.com/pattern-clone/mypattern
     targetRevision: main
   gitOpsSpec:
-    operatorChannel: stable
+    operatorChannel: gitops-1.8
 ---
 # Source: pattern-install/templates/subscription.yaml
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
- Make sure clusters always has an empty default
- Do not validate certs when we use letsencrypt on the endpoints
- Update the gitops patterns CRD
- Switch to gitops-1.8 channel in common
- Add a change entry for gitops-1.8
- Do not apply the ocp-gitops-policy on the hub via ACM
- Do not hardcode the gitops version that gets installed on spokes
- Fix up common/ tests
