### PR TITLE
Make the registry explicit with the obsidiandynamics/kafdrop:latest image

### DIFF
--- a/charts/all/kafdrop/values.yaml
+++ b/charts/all/kafdrop/values.yaml
@@ -8,7 +8,7 @@ kafka:
     replicas: 3
   deployment:
     replicas: 1
-    image: "obsidiandynamics/kafdrop:latest"
+    image: "docker.io/obsidiandynamics/kafdrop:latest"
     env:
       - name: KAFKA_BROKERCONNECT
         value: "xray-cluster-kafka-0.xray-cluster-kafka-brokers.xraylab-1.svc:9092"

--- a/charts/all/kafka/values.yaml
+++ b/charts/all/kafka/values.yaml
@@ -9,7 +9,7 @@ kafka:
     replicas: 3
   deployment:
     replicas: 1
-    image: "obsidiandynamics/kafdrop:latest"
+    image: "docker.io/obsidiandynamics/kafdrop:latest"
     env:
       - name: KAFKA_BROKERCONNECT
         value: "xray-cluster-kafka-0.xray-cluster-kafka-brokers.xraylab-1.svc:9092"

--- a/tests/all-kafdrop-industrial-edge-factory.expected.yaml
+++ b/tests/all-kafdrop-industrial-edge-factory.expected.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: kafdrop
-          image: obsidiandynamics/kafdrop:latest
+          image: docker.io/obsidiandynamics/kafdrop:latest
           ports:
             - containerPort: 9000
           env:

--- a/tests/all-kafdrop-industrial-edge-hub.expected.yaml
+++ b/tests/all-kafdrop-industrial-edge-hub.expected.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: kafdrop
-          image: obsidiandynamics/kafdrop:latest
+          image: docker.io/obsidiandynamics/kafdrop:latest
           ports:
             - containerPort: 9000
           env:

--- a/tests/all-kafdrop-medical-diagnosis-hub.expected.yaml
+++ b/tests/all-kafdrop-medical-diagnosis-hub.expected.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: kafdrop
-          image: obsidiandynamics/kafdrop:latest
+          image: docker.io/obsidiandynamics/kafdrop:latest
           ports:
             - containerPort: 9000
           env:

--- a/tests/all-kafdrop-naked.expected.yaml
+++ b/tests/all-kafdrop-naked.expected.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: kafdrop
-          image: obsidiandynamics/kafdrop:latest
+          image: docker.io/obsidiandynamics/kafdrop:latest
           ports:
             - containerPort: 9000
           env:

--- a/tests/all-kafdrop-normal.expected.yaml
+++ b/tests/all-kafdrop-normal.expected.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: kafdrop
-          image: obsidiandynamics/kafdrop:latest
+          image: docker.io/obsidiandynamics/kafdrop:latest
           ports:
             - containerPort: 9000
           env:


### PR DESCRIPTION
Don't just assume that `obsidiandynamics/kafdrop:latest` always points
to docker.io automatically. Be explicit.

Tested with:

    podman pull docker.io/obsidiandynamics/kafdrop:latest
    Trying to pull docker.io/obsidiandynamics/kafdrop:latest...
    Getting image source signatures
    Copying blob 86fbbbe1ee3f [=>------------------------------------] 10.3MiB / 172.0MiB
    ...

The reason this is needed is that when we install certain operators from
an IIB (Image Index Bundle), we also need to whitelist which registries
a machine is allowed to connect to and making this explicit makes this
work in a more obvious manner.
