### PR TITLE
Fix fetching the bundle name when loading an IIB

### DIFF
--- a/common/ansible/roles/iib_ci/tasks/fetch-operator-images.yml
+++ b/common/ansible/roles/iib_ci/tasks/fetch-operator-images.yml
@@ -43,7 +43,7 @@
 - name: Read the operator bundle from the default channel
   ansible.builtin.shell: |
     set -o pipefail
-    podman run -it --rm "{{ iib_image }}" alpha list channels /configs "{{ item }}" | grep --word-regexp "{{ default_channel }}" | awk '{ print $3 }'
+    podman run -it --rm "{{ iib_image }}" alpha list channels /configs "{{ item }}" | grep -E "(\s){{ default_channel }}(\s)" | awk '{ print $3 }'
   register: bundle_channel_raw
 
 - name: Set bundle fact


### PR DESCRIPTION
The current -w grep command matches channels even when they are
substrings of each other like for the serverless-operator:

  $ podman run -i --rm $INDEX_IMAGES alpha list channels /configs "${OPERATOR}" |grep --word-regexp "stable"
  serverless-operator  stable       serverless-operator.v1.30.0
  serverless-operator  stable-1.29  serverless-operator.v1.29.1
  serverless-operator  stable-1.30  serverless-operator.v1.30.0

This then causes error when trying to parse the list of images as we
will have multiple images because we break the one image per line
assumption.

Let's fix this by adding spaces around the grep. Ideall we'd use the
opm render command, but the parsing of all the yaml output seems a bit
much to do for this simple use case.
