### PR TITLE
Fix small typo in subscription dictionary name

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -26,7 +26,7 @@ clusterGroup:
       name: odf-operator
       namespace: openshift-storage
 
-    severless:
+    serverless:
       name: serverless-operator
 
   projects:


### PR DESCRIPTION
While this is normally irrelevant, it matters when we override the
subscription via IIB, so let's give it the proper name
