### PR TITLE
Upgrade super-linter to v8.5.0

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -2,5 +2,8 @@
     "default": true,
     "MD003": false,
     "MD013": false,
-    "MD033": false
+    "MD033": false,
+    "MD059": false,
+    "MD060": false,
+    "MD034": false
 }

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -3,6 +3,8 @@ name: Super linter
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
     # Name the Job
@@ -12,8 +14,9 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
@@ -21,10 +24,11 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7
+        uses: super-linter/super-linter/slim@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
+          FILTER_REGEX_EXCLUDE: .+/\.github/.*
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # These are the validation we disable atm
           VALIDATE_ANSIBLE: false
@@ -40,5 +44,12 @@ jobs:
           VALIDATE_YAML_PRETTIER: false
           # VALIDATE_DOCKERFILE_HADOLINT: false
           # VALIDATE_MARKDOWN: false
-          # VALIDATE_NATURAL_LANGUAGE: false
           # VALIDATE_TEKTON: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
+          VALIDATE_SPELL_CODESPELL: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_PYINK: false
+          VALIDATE_PYTHON_RUFF_FORMAT: false
+          VALIDATE_TRIVY: false

--- a/.github/workflows/sync-rhdp-branch.yml
+++ b/.github/workflows/sync-rhdp-branch.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   sync-branches:
     if: |
@@ -15,14 +17,17 @@ jobs:
     name: Git Sync branch
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          persist-credentials: false
           node-version: 20
       - name: Opening pull request
         id: pull
-        uses: mbaldessari/git-sync-branch@v0.2.0
+        uses: mbaldessari/git-sync-branch@dd2adf0ca96e52c64716d83cabe85fac33201e12 # v0.2.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FROM_BRANCH: "main"

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -10,14 +10,16 @@ on:
       - "pattern-metadata.yaml"
       - ".github/workflows/update-metadata.yml"
 
+permissions: read-all
+
 jobs:
   update-metadata:
-    uses: validatedpatterns/docs/.github/workflows/metadata-docs.yml@main
+    uses: validatedpatterns/docs/.github/workflows/metadata-docs.yml@main # zizmor: ignore[unpinned-uses]
     permissions: # Workflow-level permissions
       contents: read  # Required for "read-all"
       packages: write # Allows writing to packages
       id-token: write # Allows creating OpenID Connect (OIDC) tokens
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     # For testing you can point to a different branch in the docs repository
     # with:
     #  DOCS_BRANCH: "main"


### PR DESCRIPTION
- Pin super-linter to v8.5.0 (SHA 61abc07d)
- Pin all GitHub Actions to SHA references
- Add persist-credentials: false to checkout steps
- Add permissions: read-all to workflow files
- Add dependabot cooldown and grouping configuration
- Disable new v8 linters not applicable to this repo
- Add FILTER_REGEX_EXCLUDE for nested .github directories
- Add zizmor ignore comments for reusable workflow refs
- Update markdownlint config for new rules
- Migrate ansible-lint-action to ansible/ansible-lint

